### PR TITLE
attempt to implement a laxSpacing option

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -23,5 +23,6 @@ module.exports = {
   smartLists: false,
   smartypants: false,
   tables: true,
-  xhtml: false
+  xhtml: false,
+  laxSpacing: false
 };

--- a/lib/grammar/block.js
+++ b/lib/grammar/block.js
@@ -20,6 +20,7 @@ var substitute = require('../utils/substitute');
 
 var block = module.exports = {};
 
+block.alnum      = /[a-zA-Z0-9]/;
 block.blockquote = /^( *>[^\n]+(\n(?!def)[^\n]+)*\n*)+/;
 block.bullet     = /(?:[*+-]|\d+\.)/;
 block.closed     = /<(tag)[\s\S]+?<\/\1>/;

--- a/lib/lexer-block.js
+++ b/lib/lexer-block.js
@@ -47,9 +47,17 @@ lexers.push(function code(self, state) {
     return false;
   }
 
-  if (self._options.laxSpacing) {
-    state.src = state.src.replace(/^ {4}/gm, '');
-    return false;
+  if (self._options.laxSpacing && !self.rules.alnum.exec(state.src[4])) {
+    var newSrc = state.src.replace(/^ {4}/gm, '');
+
+    if (self.rules.list.exec(newSrc) ||
+        self.rules.item.exec(newSrc) ||
+        self.rules.blockquote.exec(newSrc) ||
+        self.rules.fences.exec(newSrc)) {
+
+      state.src = newSrc;
+      return false;
+    }
   }
 
   state.src = state.src.substring(cap[0].length);

--- a/lib/lexer-block.js
+++ b/lib/lexer-block.js
@@ -47,6 +47,11 @@ lexers.push(function code(self, state) {
     return false;
   }
 
+  if (self._options.laxSpacing) {
+    state.src = state.src.replace(/^ {4}/gm, '');
+    return false;
+  }
+
   state.src = state.src.substring(cap[0].length);
   cap = cap[0].replace(/^ {4}/gm, '');
   self.tokens.push({

--- a/lib/lexer-block.js
+++ b/lib/lexer-block.js
@@ -48,7 +48,7 @@ lexers.push(function code(self, state) {
   }
 
   if (self._options.laxSpacing && !self.rules.alnum.exec(state.src[4])) {
-    var newSrc = state.src.replace(/^ {4}/gm, '');
+    var newSrc = state.src.substring(4);
 
     if (self.rules.list.exec(newSrc) ||
         self.rules.item.exec(newSrc) ||

--- a/test/actual/lax_spacing.html
+++ b/test/actual/lax_spacing.html
@@ -5,4 +5,5 @@
 </ul>
 </li>
 </ul>
-<p>text</p>
+<pre><code>text
+</code></pre>

--- a/test/actual/lax_spacing.html
+++ b/test/actual/lax_spacing.html
@@ -1,0 +1,8 @@
+<ul>
+<li><p>item1</p>
+<ul>
+<li>item2</li>
+</ul>
+</li>
+</ul>
+<p>text</p>

--- a/test/fixtures/lax_spacing.html
+++ b/test/fixtures/lax_spacing.html
@@ -1,0 +1,1 @@
+<ul><li><p>item1</p>  <ul><li>item2 </li></ul> </li></ul> <p>text</p>

--- a/test/fixtures/lax_spacing.html
+++ b/test/fixtures/lax_spacing.html
@@ -1,1 +1,1 @@
-<ul><li><p>item1</p>  <ul><li>item2 </li></ul> </li></ul> <p>text</p>
+<ul><li><p>item1</p>  <ul><li>item2 </li></ul> </li></ul> <pre><code>text</code></pre>

--- a/test/fixtures/lax_spacing.md
+++ b/test/fixtures/lax_spacing.md
@@ -2,4 +2,5 @@
 
       * item2
 
+
     text

--- a/test/fixtures/lax_spacing.md
+++ b/test/fixtures/lax_spacing.md
@@ -1,0 +1,5 @@
+    * item1
+
+      * item2
+
+    text

--- a/test/test_code.js
+++ b/test/test_code.js
@@ -66,4 +66,16 @@ describe('code', function () {
       expect(normalize(actual)).to.equal(normalize(expected));
     });
   });
+
+  describe('laxSpacing', function () {
+    it('should not detect code blocks beginning with spaces when laxSpacing = true', function () {
+      var testfile = 'lax_spacing';
+      var fixture = helper.readFile(testfile + '.md');
+      var actual = remarked(fixture, {laxSpacing: true});
+
+      helper.writeActual(testfile, actual);
+      var expected = helper.readFile(testfile + '.html');
+      expect(normalize(actual)).to.equal(normalize(expected));
+    });
+  });
 });

--- a/test/test_set_options.js
+++ b/test/test_set_options.js
@@ -22,7 +22,8 @@ describe('.setOptions', function () {
       pedantic: false,
       sanitize: false,
       smartLists: false,
-      smartypants: false
+      smartypants: false,
+      laxSpacing: false
     });
 
     remarked('');
@@ -37,5 +38,6 @@ describe('.setOptions', function () {
     expect(actualOptions).to.have.property('sanitize', false);
     expect(actualOptions).to.have.property('smartLists', false);
     expect(actualOptions).to.have.property('smartypants', false);
+    expect(actualOptions).to.have.property('laxSpacing', false);
   });
 });


### PR DESCRIPTION
The idea here was to match the LAX_SPACING option from the sundown parser. See [here](https://github.com/vmg/sundown/blob/37728fb2d7137ff7c37d0a474cb827a8d6d846d8/src/markdown.c#L1464-L1484).

Due to the fact that the parsing is _completely_ different, I'm not sure that this was the exact best approach, but I went for a 1:1 translation for now.
